### PR TITLE
Add request forwarding to mock

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,13 @@ export default {
 
   // 支持自定义函数，API 参考 express@4
   'POST /api/users/create': (req, res) => { res.end('OK'); },
+
+  // Forward 到另一个服务器
+  'GET /assets/*': 'https://assets.online/',
+
+  // Forward 到另一个服务器，并指定子路径
+  // 请求 /someDir/0.0.50/index.css 会被代理到 https://g.alicdn.com/tb-page/taobao-home, 实际返回 https://g.alicdn.com/tb-page/taobao-home/0.0.50/index.css
+  'GET /someDir/(.*)': 'https://g.alicdn.com/tb-page/taobao-home',
 };
 ```
 

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "css-loader": "^0.26.1",
     "detect-port": "^1.0.7",
     "explain-error": "^1.0.3",
+    "express-http-proxy": "^0.11.0",
     "extract-text-webpack-plugin": "^1.0.1",
     "file-loader": "^0.9.0",
     "filesize": "^3.3.0",


### PR DESCRIPTION
支持下面两种情况：

```
// Forward 到另一个服务器，不指定来源服务器
'GET /assets/*': 'https://assets.online/',

// Forward 到另一个服务器，并指定子路径
// 请求 /someDir/0.0.50/index.css 会被代理到 https://g.alicdn.com/tb-page/taobao-home, 实际返回 https://g.alicdn.com/tb-page/taobao-home/0.0.50/index.css
'GET /someDir/(.*)': 'https://g.alicdn.com/tb-page/taobao-home',
```
close #174 