### PR TITLE
Fix mock regex rule

### DIFF
--- a/test/scripts/server-test.js
+++ b/test/scripts/server-test.js
@@ -17,13 +17,13 @@ describe('server', () => {
           got('http://localhost:8000/a'),
           got('http://localhost:8000/b'),
           got('http://localhost:8000/tb-page/taobao-home/0.0.50/index.css'),
-          // got('http://localhost:8000/someDir/0.0.50/index.css'),
+          got('http://localhost:8000/someDir/0.0.50/index.css'),
         ]).then((res) => {
           const data = res.map(item => item.body);
           expect(data[0]).toEqual('a');
           expect(data[1]).toEqual('{"data":"b"}');
           expect(data[2].indexOf('.iconfont,.tb-icon,body')).toEqual(0);
-          // expect(data[3].indexOf('.iconfont,.tb-icon,body')).toEqual(0);
+          expect(data[3].indexOf('.iconfont,.tb-icon,body')).toEqual(0);
           p.kill('SIGINT');
           done();
         });


### PR DESCRIPTION
手动在 `server/mock` 目录下测试是可以了，不过跑 `npm run test` 还是有报错，不清楚是哪里来的。