### PR TITLE
Devtool with production can be config

### DIFF
--- a/src/config/webpack.config.dev.js
+++ b/src/config/webpack.config.dev.js
@@ -31,6 +31,7 @@ export default function (config, cwd) {
   const {
     library = null,
     libraryTarget = 'var',
+    devtool = '#cheap-module-eval-source-map',
   } = config;
 
   const cssLoaders = getCSSLoaders(config);
@@ -61,7 +62,7 @@ export default function (config, cwd) {
   ] : [];
 
   const finalWebpackConfig = {
-    devtool: 'cheap-module-source-map',
+    devtool,
     entry: getEntry(config, paths.appDirectory),
     output,
     resolve: {

--- a/src/config/webpack.config.prod.js
+++ b/src/config/webpack.config.prod.js
@@ -31,6 +31,7 @@ export default function (args, appBuild, config, paths) {
     publicPath = '/',
     library = null,
     libraryTarget = 'var',
+    devtool = null,
   } = config;
 
   const cssLoaders = getCSSLoaders(config);
@@ -210,6 +211,8 @@ export default function (args, appBuild, config, paths) {
       tls: 'empty',
     },
   };
+
+  if (devtool) finalWebpackConfig.devtool = devtool;
 
   if (config.svgSpriteLoaderDirs) {
     baseSvgLoader.exclude = config.svgSpriteLoaderDirs;


### PR DESCRIPTION
https://webpack.github.io/docs/configuration.html#devtool 

> Prefixing @, # or #@ will enforce a pragma style. (Defaults to @ in webpack@1 and # in webpack@2; using # is recommended)

同时，`cheap-module-eval-source-map` 是比较合适开发环境的。

关于生产环境的配置还是**有机会**完全让用户配置是否开启