### PR TITLE
disable dev-server host check

### DIFF
--- a/src/runServer.js
+++ b/src/runServer.js
@@ -150,6 +150,7 @@ function runDevServer(host, port, protocol) {
     https: protocol === 'https',
     host,
     proxy: rcConfig.proxy,
+    disableHostCheck: true,
   });
 
   addMiddleware(devServer);


### PR DESCRIPTION
https://github.com/webpack/webpack-dev-server/releases/tag/v2.4.3

> We added a check for the correct Host header to the webpack-dev-server.
This allowed evil websites to access your assets.

> The Host header of the request have to match the listening adress or the host provided in the public option.

> The response will contain a note when using an incorrect Host header.

> For usage behind a Proxy or similar setups we also added a disableHostCheck option to disable this check.