### PR TITLE
fix: 修复 entry 不兼容 .ts 文件问题

### DIFF
--- a/src/utils/getEntry.js
+++ b/src/utils/getEntry.js
@@ -5,7 +5,7 @@ import glob from 'glob';
 const DEFAULT_ENTRY = './src/index.js';
 
 function getEntry(filePath, isBuild) {
-  const key = basename(filePath, '.js');
+  const key = basename(filePath).replace(/\.(js|tsx?)$/, '');
   const value = isBuild
     ? [filePath]
     : [

--- a/test/utils/getEntry-test.js
+++ b/test/utils/getEntry-test.js
@@ -1,11 +1,18 @@
 import { join } from 'path';
 import expect from 'expect';
-import { getFiles } from '../../src/utils/getEntry';
+import { getFiles, getEntries } from '../../src/utils/getEntry';
 
 const fixtures = join(__dirname, '..', 'fixtures');
 const getEntryFixture = join(fixtures, 'getEntry');
 
 describe('getEntry', () => {
+
+  it('ts', () => {
+    expect(getEntries(['./src/a.js'], getEntryFixture)).toEqual({
+      a: ['./src/a.js']
+    });
+  })
+
   it('array', () => {
     expect(getFiles(['./src/a.js'], getEntryFixture)).toEqual([
       './src/a.js',


### PR DESCRIPTION
当 entry 为 .ts, .tsx 后缀时， 生成 entry 不正确

例如： 
index.ts -> index.ts.js
index.tsx -> index.tsx.js