### PR TITLE
fix: 修复基于 roadhog 的 dva typescript 不能运行的问题。

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "dependencies": {
     "atool-monitor": "^0.4.3",
     "autoprefixer": "^7.1.1",
-    "awesome-typescript-loader": "^3.0.0-beta.18",
+    "awesome-typescript-loader": "^3.1.3",
     "babel-core": "^6.20.0",
     "babel-loader": "^7.0.0",
     "babel-plugin-add-module-exports": "^0.2.1",

--- a/src/config/common.js
+++ b/src/config/common.js
@@ -101,7 +101,12 @@ export function getLastRules({ paths, babelOptions }) {
           loader: 'babel',
           options: babelOptions,
         },
-        'awesome-typescript',
+        {
+          loader: 'awesome-typescript',
+          options: {
+            transpileOnly: true,
+          },
+        },
       ],
     },
   ];


### PR DESCRIPTION
具体做法为
```
dva new ts-dva-demo
```
然后把所有文件名改为 .ts .tsx。
加入 tsconfig.json
```json
{
    "compilerOptions": {
        "lib": ["es2016", "dom"],
        "target": "es6",
        "moduleResolution": "node",
        "jsx": "preserve",
        "module": "es2015",
        "experimentalDecorators": true,
        "allowSyntheticDefaultImports": true,
        "sourceMap": true,
        "noUnusedParameters": true,
        "noUnusedLocals": true
    },
    "exclude": [
        "node_modules"
    ]
}
```