### PR TITLE
fix: production devtool  默认配置兼容 webpack2

### DIFF
--- a/src/config/webpack.config.prod.js
+++ b/src/config/webpack.config.prod.js
@@ -26,7 +26,7 @@ export default function (args, appBuild, config, paths) {
     publicPath = '/',
     library = null,
     libraryTarget = 'var',
-    devtool = debug ? defaultDevtool : null,
+    devtool = debug ? defaultDevtool : false,
   } = config;
 
   const babelOptions = getBabelOptions(config);


### PR DESCRIPTION
https://webpack.js.org/configuration/devtool/
- configuration.devtool should be one of these: string | false