### PR TITLE
fix hash bug

### DIFF
--- a/src/config/common.js
+++ b/src/config/common.js
@@ -307,7 +307,7 @@ export function getCommonPlugins({ config, paths, appBuild, NODE_ENV }) {
   }
   if (config.multipage) {
     // Support hash
-    const name = config.hash ? 'common.[chunkhash]' : 'common';
+    const name = config.hash ? 'common.[hash]' : 'common';
     ret.push(new webpack.optimize.CommonsChunkPlugin({
       name: 'common',
       filename: `${name}.js`,


### PR DESCRIPTION
修复 `multipage` 情况下，`npm run start` 会报错：

```bash
Failed to compile.

chunk common [entry]
common.[chunkhash].js
Cannot use [chunkhash] for chunk in 'common.[chunkhash].js' (use [hash] instead)
```