### PR TITLE
entry support `.jsx` files and fix hmr unavailable  when entry is plan-object

### DIFF
--- a/src/utils/getEntry.js
+++ b/src/utils/getEntry.js
@@ -6,7 +6,7 @@ import isPlainObject from 'is-plain-object';
 const DEFAULT_ENTRY = './src/index.js';
 
 function getEntry(filePath, isBuild) {
-  const key = basename(filePath).replace(/\.(js|jsx|tsx?)$/, '');
+  const key = basename(filePath).replace(/\.(js|tsx?)$/, '');
   const value = isBuild
     ? [filePath]
     : [
@@ -50,14 +50,13 @@ export default function (config, appDirectory, isBuild) {
       return entry;
     }
 
-    return Object.keys(entry).reduce((memo, key) => {
-      return Object.assign(memo, {
-        [key]: [
-          require.resolve('react-dev-utils/webpackHotDevClient'),
-          entry[key],
-        ],
-      });
-    }, {});
+    return Object.keys(entry).reduce((memo, key) => ({
+      ...memo,
+      [key]: [
+        require.resolve('react-dev-utils/webpackHotDevClient'),
+        entry[key],
+      ],
+    }), {});
   }
   const files = entry ? getFiles(entry, appDirectory) : [DEFAULT_ENTRY];
   return getEntries(files, isBuild);

--- a/src/utils/getEntry.js
+++ b/src/utils/getEntry.js
@@ -6,7 +6,7 @@ import isPlainObject from 'is-plain-object';
 const DEFAULT_ENTRY = './src/index.js';
 
 function getEntry(filePath, isBuild) {
-  const key = basename(filePath).replace(/\.(js|tsx?)$/, '');
+  const key = basename(filePath).replace(/\.(js|jsx|tsx?)$/, '');
   const value = isBuild
     ? [filePath]
     : [
@@ -46,7 +46,18 @@ export function getEntries(files, isBuild) {
 export default function (config, appDirectory, isBuild) {
   const entry = config.entry;
   if (isPlainObject(entry)) {
-    return entry;
+    if (isBuild) {
+      return entry;
+    }
+
+    return Object.keys(entry).reduce((memo, key) => {
+      return Object.assign(memo, {
+        [key]: [
+          require.resolve('react-dev-utils/webpackHotDevClient'),
+          entry[key],
+        ],
+      });
+    }, {});
   }
   const files = entry ? getFiles(entry, appDirectory) : [DEFAULT_ENTRY];
   return getEntries(files, isBuild);


### PR DESCRIPTION
Fixed: 
1. entry support `.jsx` files. if the entry is `./src/index.jsx`, with current version the build result is:

    ```
    index.jsx.js
    index.jsx.css
    ``` 
    Maybe we can directly remove the suffix of the entry, but this MR just compatibility with `.jsx` files. 

2. hmr unavailable  when entry is plan-object. If the entry is `{main: './src/index.js'}` the hmr will not be setup.

Related issue [#378](https://github.com/sorrycc/roadhog/issues/378)