### PR TITLE
:bug: utils.getEntry with hotModuleReload.

### DIFF
--- a/src/utils/getEntry.js
+++ b/src/utils/getEntry.js
@@ -50,13 +50,16 @@ export default function (config, appDirectory, isBuild) {
       return entry;
     }
 
-    return Object.keys(entry).reduce((memo, key) => ({
+    return Object.keys(entry).reduce((memo, key) => (!Array.isArray(entry[key]) ? ({
       ...memo,
       [key]: [
         require.resolve('react-dev-utils/webpackHotDevClient'),
         entry[key],
       ],
-    }), {});
+    }) : ({
+      ...memo,
+      [key]: entry[key],
+    })), {});
   }
   const files = entry ? getFiles(entry, appDirectory) : [DEFAULT_ENTRY];
   return getEntries(files, isBuild);


### PR DESCRIPTION
According to webpack source code (`webpack/webpack/blob/master/lib/EntryOptionPlugin`), entry does not support { key: [ singleEntry, Array ] }. That is, when entry like 

```json
{
  "enrtry": {
    "index": "./src/index.js",
    "vendor": ["react", "redux"]
  }
  ...
}
```

with hotModuleReload, it will throw an **error**.