### PR TITLE
修复两个问题：

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "html-webpack-plugin": "^2.30.1",
     "http-proxy-middleware": "^0.17.3",
     "is-plain-object": "^2.0.3",
-    "istanbul": "^0.4.5",
+    "istanbul": "^1.0.0-alpha",
     "less": "^2.7.1",
     "less-loader": "^4.0.3",
     "lodash.pullall": "^4.2.0",

--- a/src/test.js
+++ b/src/test.js
@@ -21,7 +21,7 @@ const mochaBin = require.resolve('mocha/bin/_mocha');
 const istanbul = join(require.resolve('istanbul'), '../lib/cli.js');
 const cmd = argv.coverage ?
   `node ${istanbul} cover ${mochaBin} -- --compilers .:${compiler} --require ${setup} ${mochaArgs}` :
-  `${mochaBin} --compilers .:${compiler} --require ${setup} ${mochaArgs}`;
+  `node ${mochaBin} --compilers .:${compiler} --require ${setup} ${mochaArgs}`;
 
 const command = (os.platform() === 'win32' ? 'cmd.exe' : 'sh');
 const args = (os.platform() === 'win32' ? ['/s', '/c'] : ['-c']);


### PR DESCRIPTION
- 在 script 中运行 `roadhog test` 提示 _mocha 不是可执行文件的报错
- 在运行 roadhog test --coverage 时无法如愿显示覆盖率信息的问题

### issue 出处: https://github.com/sorrycc/roadhog/pull/147