### PR TITLE
Replace order of dependency resolving - prefer app dependencies first

### DIFF
--- a/src/config/common.js
+++ b/src/config/common.js
@@ -44,8 +44,8 @@ export function getResolve(config, paths) {
   return {
     resolve: {
       modules: [
-        paths.ownNodeModules,
         paths.appNodeModules,
+        paths.ownNodeModules,
         'node_modules',
       ],
       extensions: [
@@ -56,8 +56,8 @@ export function getResolve(config, paths) {
     },
     resolveLoader: {
       modules: [
-        paths.ownNodeModules,
         paths.appNodeModules,
+        paths.ownNodeModules,
       ],
       moduleExtensions: ['-loader'],
     },


### PR DESCRIPTION
Using Windows, roadhog 1.2.2 (global), roadhog installed in C: and project in D:.
Using 'roadhog build' produces a binary with ownNodeModules over appNodeModules, for instance, React version is 0.14.9, regardless of app's package.json.

This fixes #454, #396 