### PR TITLE
feat: entry support '.jsx' file extension

### DIFF
--- a/src/utils/getEntry.js
+++ b/src/utils/getEntry.js
@@ -6,7 +6,7 @@ import isPlainObject from 'is-plain-object';
 const DEFAULT_ENTRY = './src/index.js';
 
 function getEntry(filePath, isBuild) {
-  const key = basename(filePath).replace(/\.(js|tsx?)$/, '');
+  const key = basename(filePath).replace(/\.(jsx?|tsx?)$/, '');
   const value = isBuild
     ? [filePath]
     : [

--- a/test/utils/getEntry-test.js
+++ b/test/utils/getEntry-test.js
@@ -13,6 +13,12 @@ describe('getEntry', () => {
     });
   });
 
+  it('jsx', () => {
+    expect(getEntries(['./src/a.jsx'], getEntryFixture)).toEqual({
+      a: ['./src/a.jsx'],
+    });
+  });
+
   it('array', () => {
     expect(getFiles(['./src/a.js'], getEntryFixture)).toEqual([
       './src/a.js',


### PR DESCRIPTION
当 entry 为 index.jsx 时，编译出的文件为 ‘index.jsx.js’ ‘index.jsx.css’ 十分不科学