### PR TITLE
Downgrade `strip-ansi` package to 3.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "react-dev-utils": "^2.0.1",
     "recursive-readdir": "^2.2.1",
     "rimraf": "^2.5.4",
-    "strip-ansi": "^3.0.1",
+    "strip-ansi": "3.0.1",
     "strip-json-comments": "^2.0.1",
     "style-loader": "^0.18.1",
     "svg-sprite-loader": "^3.1.2",


### PR DESCRIPTION
fix the uncompiled code for dev in IE11
fix this: https://github.com/dvajs/dva/issues/1233