### PR TITLE
[feat] 重新支持 --no-open 命令参数

### DIFF
--- a/src/dev.js
+++ b/src/dev.js
@@ -53,6 +53,9 @@ export default function runDev(opts = {}) {
     paths,
   });
 
+  // 判断是否要开启浏览器
+  const openBrowser = process.argv.every(param => param !== '--no-open');
+
   dev({
     webpackConfig,
     proxy: config.proxy || {},
@@ -66,6 +69,6 @@ export default function runDev(opts = {}) {
     afterServer(devServer) {
       returnedWatchConfig(devServer);
     },
-    openBrowser: true,
+    openBrowser,
   });
 }


### PR DESCRIPTION
自动开启浏览器这个特性，在 win 平台下实在是太痛苦。
看你之前的提交，是有此参数的，不知后来为什么又去掉了