### PR TITLE
Fix the javascript sourceMap missing bug

### DIFF
--- a/src/config/webpack.config.prod.js
+++ b/src/config/webpack.config.prod.js
@@ -88,6 +88,7 @@ export default function (args, appBuild, config, paths) {
           screw_ie8: true,
           ascii_only: true,
         },
+        sourceMap: true,
       })]),
       ...(analyze ? [new Visualizer()] : []),
     ],


### PR DESCRIPTION
For 1.x version, if I set the `devtool` to `"source-map"`, there isn't js sourceMap file.