### PR TITLE
feat: upgrade af-webpack and umi-test

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,8 +331,10 @@ You can temporarily configure some parameters for environment variables, includi
 * `PORT`, default 8000
 * `HOST`, default localhost
 * `ANALYZE`, whether to analyze the output bundle in `roadhog build`
-* `DISABLE_ESLINT`, disable eslint check
-* `NO_COMPRESS`, don't compress file in `roadhog build`
+* `ESLINT`, set `none` disable eslint check
+* `TSLINT`, set `none` disable tslint check
+* `COMPRESS`, set `none` to disable file compressing in `roadhog build`
+* `BROWSER`, set `none` to disable browser open in `roadhog dev`
 
 e.g. start dev server with port 3000,
 

--- a/README_zh-cn.md
+++ b/README_zh-cn.md
@@ -313,8 +313,10 @@ export default {
 * `PORT`，端口号，默认 8000
 * `HOST`，默认 localhost
 * `ANALYZE`，是否在 build 时分析构建产物
-* `DISABLE_ESLINT`，禁用 eslint 检测
-* `NO_COMPRESS`, build 时不压缩
+* `ESLINT`，设为 `none` 时禁用 eslint 检测
+* `TSLINT`，设为 `none` 时禁用 tslint 检测
+* `COMPRESS`, 设为 `none` 时 build 时不压缩
+* `BROWSER`, 设为 `none` 时不自动打开浏览器
 
 比如使用 3000 端口启动 dev server，
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@babel/core": "^7.0.0-beta.38",
     "@babel/polyfill": "^7.0.0-beta.38",
     "@babel/runtime": "^7.0.0-beta.38",
-    "af-webpack": "^0.15.0",
+    "af-webpack": "^0.17.2",
     "atool-monitor": "^0.4.3",
     "babel-plugin-add-module-exports": "^0.2.1",
     "babel-preset-umi": "^0.2.0",
@@ -55,7 +55,7 @@
     "lodash.escaperegexp": "^4.1.2",
     "parse-json-pretty": "^0.1.0",
     "strip-json-comments": "^2.0.1",
-    "umi-test": "^0.3.0",
+    "umi-test": "^0.4.3",
     "update-notifier": "^2.3.0",
     "yargs": "^8.0.1"
   },


### PR DESCRIPTION
Close #554

---

## CHANGELOG

build and dev

* fix sourcemap don't work, #554, umijs/umi#43
* process.env.NO_COMPRESS work for service-worker.js too
* fix typo, opts.serviceworker 大小写，#594
* force reload when process.env.RELOAD is set
* deprecate DISABLE_ESLINT, DISABLE_TSLINT, prefer ESLINT=none, TSLINT=none
* don't minify CSS when process.env.CSS_COMPRESS=none is truthy

test

* use identity-obj-proxy for css/less files
* improve test with ts

## TODO

* [x] test ant-design-pro
* [x] update docs
