### PR TITLE
feat: Disable atool monitor when ALI_MONITOR=none

### DIFF
--- a/src/roadhog.js
+++ b/src/roadhog.js
@@ -37,7 +37,10 @@ switch (aliasedScript) {
   case 'build':
   case 'dev':
   case 'test':
-    require('atool-monitor').emit();
+    if (process.env.ALI_MONITOR !== 'none') {
+      // Disable atool monitor when ALI_MONITOR=none
+      require('atool-monitor').emit();
+    }
     const proc = fork(
       require.resolve(`../lib/scripts/${aliasedScript}`),
       args,


### PR DESCRIPTION
Close #765. Just run `ALI_MONITOR=none  roadhog dev` to disable atool monitor.