### PR TITLE
[For 1.x] feat: Upgrade atool-monitor and report extra data

### DIFF
--- a/bin/roadhog.js
+++ b/bin/roadhog.js
@@ -36,7 +36,13 @@ switch (script) {
   case 'buildDll':
   case 'server':
   case 'test':
-    require('atool-monitor').emit();
+    if (script === 'server') {
+      const appData = {
+        reportFrom: 'roadhog',
+        roadhogVersion: require('../package.json').version,
+      };
+      require('atool-monitor').reportData({ appData });
+    }
     result = spawn.sync(
       'node',
       [require.resolve(`../lib/${script}`)].concat(args),

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "instrument": false
   },
   "dependencies": {
-    "atool-monitor": "^0.4.3",
+    "atool-monitor": "^1.0.9",
     "autoprefixer": "^7.1.1",
     "awesome-typescript-loader": "^3.1.3",
     "babel-core": "^6.20.0",


### PR DESCRIPTION
-  Upgrade atool-monitor to `version 1.x`.
- Add `reportFrom` and `roadhogVersion` as the extra report data.