### PR TITLE
feat: Upgrade atool-monitor and report extra data

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@babel/polyfill": "^7.0.0",
     "@babel/runtime": "^7.0.0",
     "af-webpack": "^0.23.0-beta.1",
-    "atool-monitor": "^0.4.3",
+    "atool-monitor": "^1.0.9",
     "babel-plugin-add-module-exports": "^0.2.1",
     "babel-preset-umi": "^1.0.0",
     "body-parser": "^1.17.2",

--- a/src/roadhog.js
+++ b/src/roadhog.js
@@ -37,7 +37,13 @@ switch (aliasedScript) {
   case 'build':
   case 'dev':
   case 'test':
-    require('atool-monitor').emit();
+    if (aliasedScript === 'dev') {
+      const appData = {
+        reportFrom: 'roadhog',
+        roadhogVersion: require('../package.json').version,
+      };
+      require('atool-monitor').reportData({ appData });
+    }
     const proc = fork(
       require.resolve(`../lib/scripts/${aliasedScript}`),
       args,


### PR DESCRIPTION
- Upgrade atool-monitor to version 1.x.
- Add reportFrom and roadhogVersion as the extra report data.
- Ref PR #816.